### PR TITLE
feat!: add sub-module `workspace`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,3 +16,4 @@ jobs:
         uses: terraform-docs/gh-actions@v1
         with:
           git-push: true
+          recursive: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Azure Databricks Terraform module
 
-Terraform module which creates an Azure Databricks workspace.
+Terraform module which creates Azure Databricks resources.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Terraform module which creates Azure Databricks resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.0.0 |
 
 ## Providers
@@ -18,13 +18,14 @@ Terraform module which creates Azure Databricks resources.
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_workspace"></a> [workspace](#module\_workspace) | ./modules/workspace | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [azurerm_databricks_workspace.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace) | resource |
 | [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 
 ## Inputs
@@ -35,7 +36,6 @@ No modules.
 | <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | The ID of the Log Analytics workspace to send diagnostics to. | `string` | n/a | yes |
 | <a name="input_managed_resource_group_name"></a> [managed\_resource\_group\_name](#input\_managed\_resource\_group\_name) | The name of the resource group to create the managed Databricks resources in. | `string` | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group to create the resources in. | `string` | n/a | yes |
-| <a name="input_sku"></a> [sku](#input\_sku) | The SKU of this Databricks workspace. | `string` | `"standard"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resources. | `map(string)` | `{}` | no |
 | <a name="input_workspace_name"></a> [workspace\_name](#input\_workspace\_name) | The name of this Databricks workspace. | `string` | n/a | yes |
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -11,11 +11,11 @@ resource "azurerm_resource_group" "this" {
   location = var.location
 }
 
-module "databricks" {
+module "databricks_workspace" {
   # source = "github.com/equinor/terraform-azurerm-databricks//modules/workspace"
   source = "../../modules/workspace"
 
-  workspace_name      = "dbw-${random_id.this.hex}"
+  name                = "dbw-${random_id.this.hex}"
   resource_group_name = azurerm_resource_group.this.name
   location            = azurerm_resource_group.this.location
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -11,20 +11,11 @@ resource "azurerm_resource_group" "this" {
   location = var.location
 }
 
-module "log_analytics" {
-  source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v1.1.0"
+module "databricks" {
+  # source = "github.com/equinor/terraform-azurerm-databricks//modules/workspace"
+  source = "../../modules/workspace"
 
-  workspace_name      = "log-${random_id.this.hex}"
+  workspace_name      = "dbw-${random_id.this.hex}"
   resource_group_name = azurerm_resource_group.this.name
   location            = azurerm_resource_group.this.location
-}
-
-module "databricks" {
-  # source = "github.com/equinor/terraform-azurerm-databricks"
-  source = "../.."
-
-  workspace_name             = "dbw-${random_id.this.hex}"
-  resource_group_name        = azurerm_resource_group.this.name
-  location                   = azurerm_resource_group.this.location
-  log_analytics_workspace_id = module.log_analytics.workspace_id
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -36,7 +36,6 @@ module "databricks" {
   workspace_name              = "dbw-${random_id.this.hex}"
   resource_group_name         = azurerm_resource_group.this.name
   location                    = azurerm_resource_group.this.location
-  sku                         = "premium"
   managed_resource_group_name = "rg-dbw-${random_id.this.hex}"
   log_analytics_workspace_id  = module.log_analytics.workspace_id
 

--- a/main.tf
+++ b/main.tf
@@ -1,20 +1,23 @@
-resource "azurerm_databricks_workspace" "this" {
+module "workspace" {
+  source = "./modules/workspace"
+
   name                        = var.workspace_name
   resource_group_name         = var.resource_group_name
   location                    = var.location
-  sku                         = var.sku
+  sku                         = "premium"
   managed_resource_group_name = var.managed_resource_group_name
 
   tags = var.tags
 }
 
-resource "azurerm_monitor_diagnostic_setting" "this" {
-  # Diagnostic settings require the premium SKU
-  # Ref: https://docs.microsoft.com/en-us/azure/databricks/administration-guide/account-settings/azure-diagnostic-logs#configure-diagnostic-log-delivery
-  count = var.sku == "premium" ? 1 : 0
+moved {
+  from = azurerm_databricks_workspace.this
+  to   = module.workspace.azurerm_databricks_workspace.this
+}
 
+resource "azurerm_monitor_diagnostic_setting" "this" {
   name                       = "audit-logs"
-  target_resource_id         = azurerm_databricks_workspace.this.id
+  target_resource_id         = module.workspace.id
   log_analytics_workspace_id = var.log_analytics_workspace_id
 
   # Enable all log categories that do not cost to export

--- a/modules/workspace/README.md
+++ b/modules/workspace/README.md
@@ -1,0 +1,3 @@
+# Azure Databricks workspace Terraform sub-module
+
+Terraform sub-module which creates an Azure Databricks workspace.

--- a/modules/workspace/README.md
+++ b/modules/workspace/README.md
@@ -1,3 +1,45 @@
 # Azure Databricks workspace Terraform sub-module
 
 Terraform sub-module which creates an Azure Databricks workspace.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.0.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_databricks_workspace.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_location"></a> [location](#input\_location) | The location to create the resources in. | `string` | n/a | yes |
+| <a name="input_managed_resource_group_name"></a> [managed\_resource\_group\_name](#input\_managed\_resource\_group\_name) | The name of the resource group to create the managed Databricks resources in. | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of this Databricks workspace. | `string` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group to create the resources in. | `string` | n/a | yes |
+| <a name="input_sku"></a> [sku](#input\_sku) | The SKU of this Databricks workspace. | `string` | `"standard"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resources. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | The ID of this Databricks workspace. |
+<!-- END_TF_DOCS -->

--- a/modules/workspace/main.tf
+++ b/modules/workspace/main.tf
@@ -1,0 +1,9 @@
+resource "azurerm_databricks_workspace" "this" {
+  name                        = var.workspace_name
+  resource_group_name         = var.resource_group_name
+  location                    = var.location
+  sku                         = var.sku
+  managed_resource_group_name = var.managed_resource_group_name
+
+  tags = var.tags
+}

--- a/modules/workspace/main.tf
+++ b/modules/workspace/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_databricks_workspace" "this" {
-  name                        = var.workspace_name
+  name                        = var.name
   resource_group_name         = var.resource_group_name
   location                    = var.location
   sku                         = var.sku

--- a/modules/workspace/outputs.tf
+++ b/modules/workspace/outputs.tf
@@ -1,0 +1,4 @@
+output "id" {
+  description = "The ID of this Databricks workspace."
+  value       = azurerm_databricks_workspace.this.id
+}

--- a/modules/workspace/variables.tf
+++ b/modules/workspace/variables.tf
@@ -1,4 +1,4 @@
-variable "workspace_name" {
+variable "name" {
   description = "The name of this Databricks workspace."
   type        = string
 }
@@ -13,15 +13,16 @@ variable "location" {
   type        = string
 }
 
+variable "sku" {
+  description = "The SKU of this Databricks workspace."
+  type        = string
+  default     = "standard"
+}
+
 variable "managed_resource_group_name" {
   description = "The name of the resource group to create the managed Databricks resources in."
   type        = string
   default     = null
-}
-
-variable "log_analytics_workspace_id" {
-  description = "The ID of the Log Analytics workspace to send diagnostics to."
-  type        = string
 }
 
 variable "tags" {

--- a/modules/workspace/versions.tf
+++ b/modules/workspace/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.0.0"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,1 @@
-output "workspace_id" {
-  description = "The ID of this Databricks workspace."
-  value       = azurerm_databricks_workspace.this.id
-}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,1 +1,4 @@
-
+output "workspace_id" {
+  description = "The ID of this Databricks workspace."
+  value       = module.workspace.id
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.1.0"
 
   required_providers {
     azurerm = {


### PR DESCRIPTION
Add sub-module `workspace` for creating a Databricks workspace without diagnostic settings.

Update minimum required Terraform version to `1.1.0` to support `moved` blocks.

Update phrasing in docs.

Update GitHub Actions workflow to generate docs for sub-modules.

BREAKING CHANGE: remove variable `sku`