### PR TITLE
feat: add output `managed_identity_principal_id`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,3 +51,8 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
     }
   }
 }
+
+data "azurerm_user_assigned_identity" "dbmanagedidentity" {
+  name                = "dbmanagedidentity"
+  resource_group_name = azurerm_databricks_workspace.this.managed_resource_group_name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,8 @@ output "workspace_url" {
   description = "The URL of this Databricks workspace."
   value       = azurerm_databricks_workspace.this.workspace_url
 }
+
+output "managed_identity_principal_id" {
+  description = "The principal (object) ID of the managed identity that Azure Databricks automatically creates."
+  value       = data.azurerm_user_assigned_identity.dbmanagedidentity.principal_id
+}


### PR DESCRIPTION
When creating an Azure Databricks workspace, a resource group containing resources managed by the Databricks platform is automatically created. One of these resources is a managed identity named `dbmanagedidentity`, which is assigned to the virtual machines that the Databricks clusters run on.

By outputting the object ID of this managed identity, it can be assigned additional roles, e.g. "Key Vault Secrets User" to read Key Vault secrets.