### PR TITLE
chore: add initial tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,9 @@
+name: Test
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  test:
+    name: Unit Tests
+    uses: equinor/terraform-baseline/.github/workflows/terraform-test.yml@main

--- a/README.md
+++ b/README.md
@@ -44,6 +44,22 @@ module "log_analytics" {
 }
 ```
 
+## Testing
+
+1. Initialize working directory:
+
+    ```console
+    terraform init
+    ```
+
+1. Execute tests:
+
+    ```console
+    terraform test
+    ```
+
+    See [`terraform test` command documentation](https://developer.hashicorp.com/terraform/cli/commands/test) for options.
+
 ## Contributing
 
 See [Contributing guidelines](https://github.com/equinor/terraform-baseline/blob/main/CONTRIBUTING.md).

--- a/examples/premium-databricks/main.tf
+++ b/examples/premium-databricks/main.tf
@@ -13,7 +13,8 @@ resource "random_id" "this" {
 }
 
 module "log_analytics" {
-  source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v2.1.1"
+  source  = "equinor/log-analytics/azurerm"
+  version = "~> 2.4"
 
   workspace_name      = "log-${random_id.this.hex}"
   resource_group_name = var.resource_group_name

--- a/tests/azurerm/data.tfmock.hcl
+++ b/tests/azurerm/data.tfmock.hcl
@@ -1,0 +1,11 @@
+mock_resource "azurerm_log_analytics_workspace" {
+  defaults = {
+    id = "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.OperationalInsights/workspaces/workspaceName"
+  }
+}
+
+mock_resource "azurerm_databricks_workspace" {
+  defaults = {
+    id = "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Databricks/workspaces/workspaceName"
+  }
+}

--- a/tests/examples.tftest.hcl
+++ b/tests/examples.tftest.hcl
@@ -1,0 +1,14 @@
+mock_provider "azurerm" {
+  source = "./tests/azurerm"
+}
+
+run "test_premium_databricks_example" {
+  module {
+    source = "./examples/premium-databricks"
+  }
+
+  variables {
+    resource_group_name = "example-resources"
+    location            = "westeurope"
+  }
+}

--- a/tests/examples.tftest.hcl
+++ b/tests/examples.tftest.hcl
@@ -2,7 +2,7 @@ mock_provider "azurerm" {
   source = "./tests/azurerm"
 }
 
-run "test_premium_databricks_example" {
+run "premium_databricks_example" {
   module {
     source = "./examples/premium-databricks"
   }

--- a/tests/examples.tftest.hcl
+++ b/tests/examples.tftest.hcl
@@ -13,7 +13,7 @@ variables {
   location            = run.setup_tests.location
 }
 
-run "premium_databricks_example" {
+run "test_premium_databricks_example" {
   module {
     source = "./examples/premium-databricks"
   }

--- a/tests/examples.tftest.hcl
+++ b/tests/examples.tftest.hcl
@@ -2,15 +2,15 @@ mock_provider "azurerm" {
   source = "./tests/azurerm"
 }
 
-run "setup" {
+run "setup_tests" {
   module {
     source = "./tests/setup"
   }
 }
 
 variables {
-  resource_group_name = run.setup.resource_group_name
-  location            = run.setup.location
+  resource_group_name = run.setup_tests.resource_group_name
+  location            = run.setup_tests.location
 }
 
 run "premium_databricks_example" {

--- a/tests/examples.tftest.hcl
+++ b/tests/examples.tftest.hcl
@@ -2,13 +2,19 @@ mock_provider "azurerm" {
   source = "./tests/azurerm"
 }
 
+run "setup" {
+  module {
+    source = "./tests/setup"
+  }
+}
+
+variables {
+  resource_group_name = run.setup.resource_group_name
+  location            = run.setup.location
+}
+
 run "premium_databricks_example" {
   module {
     source = "./examples/premium-databricks"
-  }
-
-  variables {
-    resource_group_name = "example-resources"
-    location            = "westeurope"
   }
 }

--- a/tests/setup/main.tf
+++ b/tests/setup/main.tf
@@ -1,0 +1,10 @@
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "westeurope"
+}
+
+resource "azurerm_log_analytics_workspace" "example" {
+  name                = "example-workspace"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+}

--- a/tests/setup/outputs.tf
+++ b/tests/setup/outputs.tf
@@ -1,0 +1,11 @@
+output "resource_group_name" {
+  value = azurerm_resource_group.example.name
+}
+
+output "location" {
+  value = azurerm_resource_group.example.location
+}
+
+output "log_analytics_workspace_id" {
+  value = azurerm_log_analytics_workspace.example.id
+}

--- a/tests/setup/terraform.tf
+++ b/tests/setup/terraform.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "4.54.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "3.7.2"
+    }
+  }
+}

--- a/tests/sku.tftest.hcl
+++ b/tests/sku.tftest.hcl
@@ -1,0 +1,38 @@
+mock_provider "azurerm" {
+  source = "./tests/azurerm"
+}
+
+run "setup" {
+  module {
+    source = "./tests/setup"
+  }
+}
+
+variables {
+  workspace_name             = "example-databricks"
+  resource_group_name        = run.setup.resource_group_name
+  location                   = run.setup.location
+  log_analytics_workspace_id = run.setup.log_analytics_workspace_id
+}
+
+run "premium_sku" {
+  variables {
+    sku = "premium"
+  }
+
+  assert {
+    condition     = azurerm_databricks_workspace.this.sku == "premium"
+    error_message = "Databricks workspace SKU should be \"premium\""
+  }
+}
+
+run "trial_sku" {
+  variables {
+    sku = "trial"
+  }
+
+  assert {
+    condition     = azurerm_databricks_workspace.this.sku == "trial"
+    error_message = "Databricks workspace SKU should be \"trial\""
+  }
+}

--- a/tests/sku.tftest.hcl
+++ b/tests/sku.tftest.hcl
@@ -15,7 +15,7 @@ variables {
   log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
 }
 
-run "premium_sku" {
+run "test_premium_sku" {
   variables {
     sku = "premium"
   }
@@ -26,7 +26,7 @@ run "premium_sku" {
   }
 }
 
-run "trial_sku" {
+run "test_trial_sku" {
   variables {
     sku = "trial"
   }

--- a/tests/sku.tftest.hcl
+++ b/tests/sku.tftest.hcl
@@ -2,7 +2,7 @@ mock_provider "azurerm" {
   source = "./tests/azurerm"
 }
 
-run "setup" {
+run "setup_tests" {
   module {
     source = "./tests/setup"
   }
@@ -10,9 +10,9 @@ run "setup" {
 
 variables {
   workspace_name             = "example-databricks"
-  resource_group_name        = run.setup.resource_group_name
-  location                   = run.setup.location
-  log_analytics_workspace_id = run.setup.log_analytics_workspace_id
+  resource_group_name        = run.setup_tests.resource_group_name
+  location                   = run.setup_tests.location
+  log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
 }
 
 run "premium_sku" {


### PR DESCRIPTION
Add initial simple tests:

- `examples.tftest.hcl`: test that the examples in for this module work.
- `sku.tftest.hcl`: test that the `sku` variable does what it should do.

Should add more tests, but keeping this PR minimal, i.e. just adding the framework needed for testing and some initial tests to see that the framework works as expected.