### PR TITLE
docs: clarify automatic identity management

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ data "http" "databricks_external_group" {
     "Content-Type"  = "application/json"
   }
   request_body = jsonencode({
-    "external_id" = "85e19454-004b-4d13-bb08-21978c58a927" # Entra ID object ID
+    "external_id" = "85e19454-004b-4d13-bb08-21978c58a927" # Object ID from Entra ID
   })
 }
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ resource "databricks_entitlements" "external_group" {
 
 Users, groups and service principals that are synced from Entra ID are shown as **External** in the workspace UI.
 
-The [`databricks_group` resource](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/group) uses the old SCIM API.
+The [`databricks_group` resource](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/group) uses the old [SCIM API](https://docs.databricks.com/api/azure/workspace/groups/create) to create groups, which will not work with automatic identity management.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ The user or service principal that creates the Databricks workspace will be auto
 
 If [Entra ID automatic identity management](https://learn.microsoft.com/en-us/azure/databricks/admin/users-groups/automatic-identity-management) is enabled for your Databricks account (enabled by default after August 1, 2025), users, groups and service principals in your Entra ID tenant will be automatically synced to your Databricks account.
 
-Use the [Databricks provider](https://registry.terraform.io/providers/databricks/databricks/latest) to assign account-level users, groups or service principals to your Databricks workspace:
+Users are automatically added at the account-level on first login (ref: [Automatically provision users](https://learn.microsoft.com/en-us/azure/databricks/security/auth/jit)). Groups should be added at the account-level by an account admin (ref: [Manage groups](https://learn.microsoft.com/en-us/azure/databricks/admin/users-groups/manage-groups)).
+
+Use a [workspace-level Databricks provider](https://registry.terraform.io/providers/databricks/databricks/latest/docs) to assign account-level users, groups or service principals to your Databricks workspace:
 
 ```terraform
 provider "databricks" {
@@ -74,7 +76,14 @@ resource "databricks_entitlements" "users" {
 }
 ```
 
-Users, groups and service principals that are synced from Entra ID are shown as **External**.
+Users, groups and service principals that are synced from Entra ID are shown as **External** in the workspace UI.
+
+Alternative approaches:
+
+- Use the [`databricks_group` resource](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/group) with an account-level provider to add an Entra ID group to your account. Requires the account admin role.
+- Use the `databricks_group` resource with a workspace-level provider to create a [legacy workspace-local group](https://learn.microsoft.com/en-us/azure/databricks/admin/users-groups/workspace-local-groups). The group will show in the workspace UI, but it won't work.
+
+It's worth noting that a workspace admin can add an Entra ID group through the workspace setting, and that group will be synced to the account. This sync from the workspace to the account will not happen if the group is created through the API using a tool like the Terraform provider. The sync can take up to 40 minutes.
 
 ## Testing
 


### PR DESCRIPTION
Clarify how to use the IAM V2 (Beta) API to add Entra ID groups to your Databricks account and then assign them to your workspace, and highlight that you should not use the `databricks_group` resource since it uses the old SCIM API.