### PR TITLE
fix(iam): workspace URL is null on initial apply

### DIFF
--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -1,5 +1,7 @@
 # Terraform module for Azure Databricks IAM
 
+> **NOTE**: This module directly calls the Databricks IAM V2 API, which is currently in beta. As such, this module should also be considered in beta. Breaking changes may occur without notice as the underlying API and provider evolve.
+
 Terraform module which creates Azure Databricks Identity and Access Management (IAM) resources.
 
 If [automatic identity management](https://learn.microsoft.com/en-us/azure/databricks/admin/users-groups/automatic-identity-management) is enabled for your Azure Databricks account (enabled by default after August 1, 2025), users, groups and service principals in your Entra ID tenant will be automatically synced to your account.
@@ -14,7 +16,8 @@ Use a [workspace-level Databricks provider](https://registry.terraform.io/provid
 module "databricks_iam" {
   source  = "equinor/databricks/azurerm//modules/iam"
   version = "~> 4.2"
-  
+
+  workspace_url = data.azurerm_databricks_workspace.example.workspace_url
   external_groups = {
     "users" = {
       external_id = "85e19454-004b-4d13-bb08-21978c58a927" # Object ID from Entra ID

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -4,9 +4,9 @@ resource "time_rotating" "this" {
 
 resource "databricks_token" "this" {
   comment = "Provision identity and access management (IAM) resources using Terraform"
-  
+
   lifetime_seconds = time_rotating.this.rotation_days * 86400 # There are 86 400 seconds per day
-  
+
   lifecycle {
     replace_triggered_by = [
       # Replace when rotation period has passed and token has expired
@@ -15,8 +15,6 @@ resource "databricks_token" "this" {
   }
 }
 
-data "databricks_current_config" "this" {}
-
 # Use the IAM V2 (Beta) API to resolve the account-level groups with the given object IDs from Entra ID.
 # If a group does not exist in the Databricks account, it will be created.
 # Ref: https://docs.databricks.com/api/azure/workspace/iamv2/resolvegroupproxy
@@ -24,7 +22,7 @@ data "http" "external_group" {
   for_each = var.external_groups
 
   method = "POST"
-  url    = "https://${data.databricks_current_config.this.host}/api/2.0/identity/groups/resolveByExternalId"
+  url    = "https://${var.workspace_url}/api/2.0/identity/groups/resolveByExternalId"
   request_headers = {
     "Authorization" = "Bearer ${databricks_token.this.token_value}"
     "Content-Type"  = "application/json"
@@ -59,7 +57,7 @@ data "databricks_group" "external_group" {
 # Set entitlements to the workspace-level groups.
 resource "databricks_entitlements" "external_group" {
   for_each = data.databricks_group.external_group
-  
+
   group_id              = each.value.id
   workspace_access      = var.external_groups[each.key].workspace_access
   databricks_sql_access = var.external_groups[each.key].databricks_sql_access

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -1,3 +1,9 @@
+variable "workspace_url" {
+  description = "The URL of the Databricks workspace to assign the identities to."
+  type        = string
+  nullable    = false
+}
+
 variable "external_groups" {
   description = "A map of external groups to assign to the Databricks workspace. To assign a user, group or service principal from Microsoft Entra ID, the external ID should match the Microsoft Entra object ID."
   type = map(object({


### PR DESCRIPTION
The initial run of `terraform apply` for this module throws the following error:

```plaintext
╷
│ Error: Invalid template interpolation value
│
│   on .terraform/modules/databricks_iam/modules/iam/main.tf line 27, in data "http" "external_group":
│   27:   url    = "https://${data.databricks_current_config.this.host}/api/2.0/identity/groups/resolveByExternalId"
│     ├────────────────
│     │ data.databricks_current_config.this.host is null
│
│ The expression result is null. Cannot include a null value in a string
│ template.
╵
```

The value of `data.databricks_current_config.this.host` is null on the initial apply, which means that it can't be used to retrieve the workspace URL of the currently configured workspace-level provider.

This data source is only required for as long as no official data source for this beta API endpoint exists in the provider- official data sources automatically target the workspace configured in the workspace-level provider. Because of this, add a note to the README that this module should be considered in beta, allowing us to add a variable `workspace_url` and then later removing it again without marking it as a breaking change.