### PR TITLE
fix(iam): permission assignment APIs are not available on initial apply

### DIFF
--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -6,6 +6,10 @@ If [automatic identity management](https://learn.microsoft.com/en-us/azure/datab
 
 Use this Terraform module to assign Entra ID users, groups and service principals to your Azure Databricks workspace.
 
+## Prerequisites
+
+- [Automatic enablement of Unity Catalog](https://learn.microsoft.com/en-us/azure/databricks/data-governance/unity-catalog/get-started#enablement)
+
 ## Usage
 
 Use a [workspace-level Databricks provider](https://registry.terraform.io/providers/databricks/databricks/latest/docs) to assign Entra ID users, groups and service principals to your workspace:

--- a/modules/iam/terraform.tf
+++ b/modules/iam/terraform.tf
@@ -4,21 +4,21 @@ terraform {
 
   required_providers {
     databricks = {
-      source  = "databricks/databricks"
+      source = "databricks/databricks"
       # Databricks provider version 1.31.0 required to use the "databricks_current_config" data source
       version = ">= 1.31.0"
     }
 
     http = {
-      source  = "hashicorp/http"
+      source = "hashicorp/http"
       # HTTP provider version 3.1.0 required to use the "method", "request_headers" and "request_body" arguments
       version = ">= 3.1.0"
     }
 
     time = {
       source = "hashicorp/time"
-      # Time provider version 0.2.0 required to use the "time_rotating" resource
-      version = ">= 0.2.0"
+      # Time provider version 0.5.0 required to use the "time_sleep" resource
+      version = ">= 0.5.0"
     }
   }
 }


### PR DESCRIPTION
The initial run of `terraform apply` for this module throws the following error:

```console
╷
│ Error: cannot create permission assignment: Permission assignment APIs are not available for this workspace.
│
│   with module.databricks_iam.databricks_permission_assignment.external_group["developer"],
│   on .terraform/modules/databricks_iam/modules/iam/main.tf line 43, in resource "databricks_permission_assignment" "external_group":
│   43: resource "databricks_permission_assignment" "external_group" {
│
╵
```

The permission assignment APIs are not available for the newly created workspace because it has not been assigned a metastore yet.

Assigning a metastore to a workspace required the account admin role. Since the goal of this module is to use a workspace-level provider configuration, we must add automatic enablement of Unity Catalog on the account as a prerequisite, then add a `time_sleep` resource to wait for a metastore to be assigned to the workspace before trying to assign permissions to groups. I could not find any official documentation for how long it takes for a metastore to be assigned to a workspace, but after testing by creating a new workspace 3 times, it seems to take around 10 minutes. I set the duration to 15 minutes just to be sure (it can be increased later if we still experience errors).