### PR TITLE
refactor(iam): rename `time_rotating.this` to `time_rotating.token_expiration`

### DIFF
--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -1,16 +1,16 @@
-resource "time_rotating" "this" {
+resource "time_rotating" "token_expiration" {
   rotation_days = 30
 }
 
 resource "databricks_token" "this" {
   comment = "Provision identity and access management (IAM) resources using Terraform"
 
-  lifetime_seconds = time_rotating.this.rotation_days * 86400 # There are 86 400 seconds per day
+  lifetime_seconds = time_rotating.token_expiration.rotation_days * 86400 # There are 86 400 seconds per day
 
   lifecycle {
     replace_triggered_by = [
       # Replace when rotation period has passed and token has expired
-      time_rotating.this.rfc3339
+      time_rotating.token_expiration.rfc3339
     ]
   }
 }

--- a/modules/iam/moved.tf
+++ b/modules/iam/moved.tf
@@ -1,0 +1,4 @@
+moved {
+  from = time_rotating.this
+  to   = time_rotating.token_expiration
+}


### PR DESCRIPTION
Better describes what the resource is used for (track token expiration), and more consistent with the name of the `time_sleep.metastore_assignment` resource.

Release-As: 4.2.2