### PR TITLE
feat(iam): assign Entra ID service principals to workspace

### DIFF
--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -32,6 +32,12 @@ module "databricks_iam" {
       admin_access = true
     }
   }
+  external_service_principals = {
+    "deploy" = {
+      external_id          = "d642b4b1-5d5a-42d2-9323-ac1677bffada" # Object ID from Entra ID
+      allow_cluster_create = true
+    }
+  }
 }
 
 provider "databricks" {

--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -11,6 +11,8 @@ Use this Terraform module to assign Entra ID users, groups and service principal
 ## Prerequisites
 
 - [Automatic enablement of Unity Catalog](https://learn.microsoft.com/en-us/azure/databricks/data-governance/unity-catalog/get-started#enablement) (enabled by default after November 9, 2023)
+- `bash`
+- `jq`
 
 ## Usage
 

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -107,7 +107,7 @@ data "http" "external_service_principal" {
 resource "databricks_permission_assignment" "external_service_principal" {
   for_each = data.http.external_service_principal
 
-  principal_id = jsondecode(each.value.response_body).service_principal.application_id
+  principal_id = jsondecode(each.value.response_body).service_principal.internal_id
   permissions  = var.external_service_principals[each.key].admin_access ? ["ADMIN"] : ["USER"]
 
   depends_on = [

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -82,6 +82,26 @@ resource "databricks_entitlements" "external_group" {
 # Use the IAM V2 (Beta) API to resolve the account-level service principals with the given object IDs from Entra ID.
 # If a service principal does not exist in the Databricks account, it will be created.
 # Ref: https://docs.databricks.com/api/azure/workspace/iamv2/resolveserviceprincipalproxy
+data "http" "external_service_principal_create" {
+  for_each = var.external_service_principals
+
+  method = "POST"
+  url    = "https://${var.workspace_url}/api/2.0/identity/servicePrincipals/resolveByExternalId"
+  request_headers = {
+    "Authorization" = "Bearer ${databricks_token.this.token_value}"
+    "Content-Type"  = "application/json"
+  }
+  request_body = jsonencode({
+    "external_id" = each.value.external_id
+  })
+
+  retry {
+    attempts     = 5
+    min_delay_ms = 1000 # 1 second
+    max_delay_ms = 5000 # 5 seconds
+  }
+}
+
 data "http" "external_service_principal" {
   for_each = var.external_service_principals
 
@@ -100,6 +120,8 @@ data "http" "external_service_principal" {
     min_delay_ms = 1000 # 1 second
     max_delay_ms = 5000 # 5 seconds
   }
+
+  depends_on = [data.http.external_service_principal_create]
 }
 
 # Assign the account-level service principals to the Databricks workspace.

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -15,6 +15,16 @@ resource "databricks_token" "this" {
   }
 }
 
+resource "time_sleep" "metastore_assignment" {
+  # Wait for a metastore to be automatically assigned to the Databricks workspace.
+  create_duration = "15m"
+
+  triggers = {
+    # If the Databricks workspace URL changes, assume that it's a new workspace and wait for a metastore to be automatically assigned to it.
+    workspace_url = var.workspace_url
+  }
+}
+
 # Use the IAM V2 (Beta) API to resolve the account-level groups with the given object IDs from Entra ID.
 # If a group does not exist in the Databricks account, it will be created.
 # Ref: https://docs.databricks.com/api/azure/workspace/iamv2/resolvegroupproxy
@@ -35,16 +45,6 @@ data "http" "external_group" {
     attempts     = 5
     min_delay_ms = 1000 # 1 second
     max_delay_ms = 5000 # 5 seconds
-  }
-}
-
-resource "time_sleep" "metastore_assignment" {
-  # Wait for a metastore to be automatically assigned to the Databricks workspace.
-  create_duration = "15m"
-
-  triggers = {
-    # If the Databricks workspace URL changes, assume that it's a new workspace and wait for a metastore to be automatically assigned to it.
-    workspace_url = var.workspace_url
   }
 }
 

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -107,7 +107,7 @@ data "http" "external_service_principal" {
 resource "databricks_permission_assignment" "external_service_principal" {
   for_each = data.http.external_service_principal
 
-  principal_id = jsondecode(each.value.response_body).service_principal.internal_id
+  principal_id = jsondecode(each.value.response_body).service_principal.application_id
   permissions  = var.external_service_principals[each.key].admin_access ? ["ADMIN"] : ["USER"]
 
   depends_on = [

--- a/modules/iam/resolve_service_principal_by_external_id.sh
+++ b/modules/iam/resolve_service_principal_by_external_id.sh
@@ -1,7 +1,8 @@
 #! /bin/bash
 #
-# Use the IAM V2 (Beta) API to resolve an account-level service principal with the given object ID from Entra ID.
-# If the service principal does not exist in the Databricks account, it will be created.
+# Use the IAM V2 (Beta) API to resolve an account-level service principal with
+# the given object ID from Entra ID. If the service principal does not exist in
+# the Databricks account, it will be created.
 #
 # Ref: https://docs.databricks.com/api/azure/workspace/iamv2/resolveserviceprincipalproxy
 #
@@ -22,32 +23,29 @@ readonly TOKEN
 EXTERNAL_ID="$3"
 readonly EXTERNAL_ID
 
-response=$(curl --silent --show-error \
-  --request POST "$API_URL" \
-  --header "Authorization: Bearer $TOKEN" \
-  --header "Content-Type: application/json" \
-  --data "{\"external_id\": \"$EXTERNAL_ID\"}"\
-  --retry 5 --retry-delay 10)
+# If the Entra ID service principal was just created, it can take a few attempts
+# before it can be resolved in Databricks.
+for (( i=0; i<5; i++ )); do
+  response=$(curl --silent --show-error \
+    --request POST "$API_URL" \
+    --header "Authorization: Bearer $TOKEN" \
+    --header "Content-Type: application/json" \
+    --data "{\"external_id\": \"$EXTERNAL_ID\"}"\
+    --retry 5 --retry-delay 10)
 
-service_principal=$(echo "$response" | jq .service_principal)
-if [[ "$service_principal" != "null" ]]; then
-  echo "$service_principal" | jq '{
-    internal_id: (.internal_id | tostring),
-    application_id: .application_id,
-    display_name: .display_name,
-    external_id: .external_id
-  }' 
-  exit 0
-fi
+  service_principal=$(echo "$response" | jq .service_principal)
+  if [[ "$service_principal" != "null" ]]; then
+    echo "$service_principal" | jq '{
+      internal_id: (.internal_id | tostring),
+      application_id: .application_id,
+      display_name: .display_name,
+      external_id: .external_id
+    }' 
+    exit 0
+  fi
 
-# TODO: handle error
-#
-# Example error:
-# "{\"error_code\":\"BAD_REQUEST\",\"message\":\"ServicePrincipal with external ID c488719c-e041-4e38-b0fc-0dc004772961 not found in IdP for account 3ef43c2c-eb9a-4237-baf4-59c0e1c4dcc4.\",\"details\":[{\"@type\":\"type.googleapis.com/google.rpc.RequestInfo\",\"request_id\":\"86e7a076-db20-41e1-9c41-f27d3b08df42\",\"serving_data\":\"\"}]}"
+  sleep "10s"
+done
 
-# error_code=$(echo "$response" | jq -r .error_code)
-# if [[ "$error_code" != "null" ]]; then
-#   echo "known error :)"
-# else 
-#   echo "unknown error :("
-# fi
+echo "Unhandled error after 5 retries: $response" >&2
+exit 1

--- a/modules/iam/resolve_service_principal_by_external_id.sh
+++ b/modules/iam/resolve_service_principal_by_external_id.sh
@@ -23,10 +23,11 @@ EXTERNAL_ID="$3"
 readonly EXTERNAL_ID
 
 # TODO: add retries?
-response=$(curl -sS -X POST "$API_URL" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "{\"external_id\": \"$EXTERNAL_ID\"}")
+response=$(curl --silent --show-error \
+  --request POST "$API_URL" \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/json" \
+  --data "{\"external_id\": \"$EXTERNAL_ID\"}")
 
 service_principal=$(echo "$response" | jq .service_principal)
 if [[ "$service_principal" != "null" ]]; then

--- a/modules/iam/resolve_service_principal_by_external_id.sh
+++ b/modules/iam/resolve_service_principal_by_external_id.sh
@@ -22,12 +22,12 @@ readonly TOKEN
 EXTERNAL_ID="$3"
 readonly EXTERNAL_ID
 
-# TODO: add retries?
 response=$(curl --silent --show-error \
   --request POST "$API_URL" \
   --header "Authorization: Bearer $TOKEN" \
   --header "Content-Type: application/json" \
-  --data "{\"external_id\": \"$EXTERNAL_ID\"}")
+  --data "{\"external_id\": \"$EXTERNAL_ID\"}"\
+  --retry 5 --retry-delay 10)
 
 service_principal=$(echo "$response" | jq .service_principal)
 if [[ "$service_principal" != "null" ]]; then

--- a/modules/iam/resolve_service_principal_by_external_id.sh
+++ b/modules/iam/resolve_service_principal_by_external_id.sh
@@ -25,7 +25,10 @@ readonly EXTERNAL_ID
 
 # If the Entra ID service principal was just created, it can take a few attempts
 # before it can be resolved in Databricks.
-for (( i=0; i<5; i++ )); do
+RETRIES=10
+readonly RETRIES
+
+for (( i=0; i<"$RETRIES"; i++ )); do
   response=$(curl --silent --show-error \
     --request POST "$API_URL" \
     --header "Authorization: Bearer $TOKEN" \
@@ -47,5 +50,5 @@ for (( i=0; i<5; i++ )); do
   sleep "10s"
 done
 
-echo "Unhandled error after 5 retries: $response" >&2
+echo "Unhandled error after $RETRIES retries: $response" >&2
 exit 1

--- a/modules/iam/resolve_service_principal_by_external_id.sh
+++ b/modules/iam/resolve_service_principal_by_external_id.sh
@@ -1,0 +1,47 @@
+#! /bin/bash
+#
+# Use the IAM V2 (Beta) API to resolve an account-level service principal with the given object ID from Entra ID.
+# If the service principal does not exist in the Databricks account, it will be created.
+#
+# Ref: https://docs.databricks.com/api/azure/workspace/iamv2/resolveserviceprincipalproxy
+#
+# Usage:
+#   ./resolve_service_principal_by_external_id.sh <WORKSPACE_URL> <TOKEN> <EXTERNAL_ID>
+
+set -e
+
+WORKSPACE_URL="$1"
+readonly WORKSPACE_URL
+
+API_URL="https://${WORKSPACE_URL}/api/2.0/identity/servicePrincipals/resolveByExternalId"
+readonly API_URL
+
+TOKEN="$2"
+readonly TOKEN
+
+EXTERNAL_ID="$3"
+readonly EXTERNAL_ID
+
+# TODO: add retries?
+response=$(curl -sS -X POST "$API_URL" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"external_id\": \"$EXTERNAL_ID\"}")
+
+service_principal=$(echo "$response" | jq .service_principal)
+if [[ "$service_principal" != "null" ]]; then
+  echo "$service_principal"
+  exit 0
+fi
+
+# TODO: handle error
+#
+# Example error:
+# "{\"error_code\":\"BAD_REQUEST\",\"message\":\"ServicePrincipal with external ID c488719c-e041-4e38-b0fc-0dc004772961 not found in IdP for account 3ef43c2c-eb9a-4237-baf4-59c0e1c4dcc4.\",\"details\":[{\"@type\":\"type.googleapis.com/google.rpc.RequestInfo\",\"request_id\":\"86e7a076-db20-41e1-9c41-f27d3b08df42\",\"serving_data\":\"\"}]}"
+
+# error_code=$(echo "$response" | jq -r .error_code)
+# if [[ "$error_code" != "null" ]]; then
+#   echo "known error :)"
+# else 
+#   echo "unknown error :("
+# fi

--- a/modules/iam/resolve_service_principal_by_external_id.sh
+++ b/modules/iam/resolve_service_principal_by_external_id.sh
@@ -30,7 +30,12 @@ response=$(curl -sS -X POST "$API_URL" \
 
 service_principal=$(echo "$response" | jq .service_principal)
 if [[ "$service_principal" != "null" ]]; then
-  echo "$service_principal"
+  echo "$service_principal" | jq '{
+    internal_id: (.internal_id | tostring),
+    application_id: .application_id,
+    display_name: .display_name,
+    external_id: .external_id
+  }' 
   exit 0
 fi
 

--- a/modules/iam/terraform.tf
+++ b/modules/iam/terraform.tf
@@ -20,5 +20,10 @@ terraform {
       # Time provider version 0.5.0 required to use the "time_sleep" resource
       version = ">= 0.5.0"
     }
+
+    external = {
+      source  = "hashicorp/external"
+      version = ">= 2.0.0"
+    }
   }
 }

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -5,7 +5,20 @@ variable "workspace_url" {
 }
 
 variable "external_groups" {
-  description = "A map of external groups to assign to the Databricks workspace. To assign a user, group or service principal from Microsoft Entra ID, the external ID should match the Microsoft Entra object ID."
+  description = "A map of external groups to assign to the Databricks workspace. To assign a group from Microsoft Entra ID, the external ID should match the Microsoft Entra group object ID."
+  type = map(object({
+    external_id           = string
+    admin_access          = optional(bool, false)
+    workspace_access      = optional(bool, true)
+    databricks_sql_access = optional(bool, true)
+    allow_cluster_create  = optional(bool, false)
+  }))
+  nullable = false
+  default  = {}
+}
+
+variable "external_service_principals" {
+  description = "A map of external service principals to assign to the Databricks workspace. To assign a service principal from Microsoft Entra ID, the external ID should match the Microsoft Entra service principal object ID."
   type = map(object({
     external_id           = string
     admin_access          = optional(bool, false)


### PR DESCRIPTION
Add support for assigning Entra ID service principals to workspace.

In #53 we used the `http` data source to call the IAM v2 API directly, however while adding support for service principals I encountered an error when creating an Azure managed identity and then immediately attempting to assign it to my workspace: the managed identity service principal had not yet had the time to be propagated to the Databricks account.

To resolve this issue, I decided to use the `external` data source instead, creating an external Bash program that wraps the API call in a for loop that retries the call 10 times (with 10s delays between each call) to give time for the propagation.

I'll migrate to the same approach for groups in a separate PR.

