### PR TITLE
fix(iam): recently created Entra ID group not found in account

### DIFF
--- a/modules/iam/resolve_group_by_external_id.sh
+++ b/modules/iam/resolve_group_by_external_id.sh
@@ -1,0 +1,53 @@
+#! /bin/bash
+#
+# Use the IAM V2 (Beta) API to resolve an account-level group with the given
+# object ID from Entra ID. If the group does not exist in the Databricks
+# account, it will be created.
+#
+# Ref: https://docs.databricks.com/api/azure/workspace/iamv2/resolvegroupproxy
+#
+# Usage:
+#   ./resolve_group_by_external_id.sh <WORKSPACE_URL> <TOKEN> <EXTERNAL_ID>
+
+set -e
+
+WORKSPACE_URL="$1"
+readonly WORKSPACE_URL
+
+API_URL="https://${WORKSPACE_URL}/api/2.0/identity/groups/resolveByExternalId"
+readonly API_URL
+
+TOKEN="$2"
+readonly TOKEN
+
+EXTERNAL_ID="$3"
+readonly EXTERNAL_ID
+
+# If the Entra ID group was just created, it can take a few attempts before it
+# can be resolved in Databricks.
+RETRIES=10
+readonly RETRIES
+
+for (( i=0; i<"$RETRIES"; i++ )); do
+  response=$(curl --silent --show-error \
+    --request POST "$API_URL" \
+    --header "Authorization: Bearer $TOKEN" \
+    --header "Content-Type: application/json" \
+    --data "{\"external_id\": \"$EXTERNAL_ID\"}"\
+    --retry 5 --retry-delay 10)
+
+  group=$(echo "$response" | jq .group)
+  if [[ "$group" != "null" ]]; then
+    echo "$group" | jq '{
+      internal_id: (.internal_id | tostring),
+      group_name: .group_name,
+      external_id: .external_id
+    }' 
+    exit 0
+  fi
+
+  sleep "10s"
+done
+
+echo "Unhandled error after $RETRIES retries: $response" >&2
+exit 1

--- a/modules/iam/terraform.tf
+++ b/modules/iam/terraform.tf
@@ -9,12 +9,6 @@ terraform {
       version = ">= 1.31.0"
     }
 
-    http = {
-      source = "hashicorp/http"
-      # HTTP provider version 3.1.0 required to use the "method", "request_headers" and "request_body" arguments
-      version = ">= 3.1.0"
-    }
-
     time = {
       source = "hashicorp/time"
       # Time provider version 0.5.0 required to use the "time_sleep" resource


### PR DESCRIPTION
If an Entra ID group is created just before attempting to assign it to a Databricks workspace (e.g., the Entra ID group is created by the same Terraform configuration as the Databricks workspace), an error may occur if there has not been enough time for the group to propagate to the Databricks account.

Migrate from the `http` data source to the `external` data source, allowing us to create a custom Bash program that attempts to resolve the group a few times before returning an error, allowing some time for recent changes to propagate to the account.

This is the same implementation as for service principals in #63.