### PR TITLE
refactor(iam): rename resources and variables

### DIFF
--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -24,7 +24,7 @@ module "databricks_iam" {
   version = "~> 4.3"
 
   workspace_url = data.azurerm_databricks_workspace.example.workspace_url
-  external_groups = {
+  groups = {
     "users" = {
       external_id = "85e19454-004b-4d13-bb08-21978c58a927" # Object ID from Entra ID
     }
@@ -34,7 +34,7 @@ module "databricks_iam" {
       admin_access = true
     }
   }
-  external_service_principals = {
+  service_principals = {
     "deploy" = {
       external_id          = "d642b4b1-5d5a-42d2-9323-ac1677bffada" # Object ID from Entra ID
       allow_cluster_create = true

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -36,7 +36,7 @@ data "external" "resolve_group_by_external_id" {
 
 # Assign the account-level groups to the Databricks workspace.
 # This will create corresponding workspace-level groups.
-resource "databricks_permission_assignment" "external_group" {
+resource "databricks_permission_assignment" "group" {
   for_each = data.external.resolve_group_by_external_id
 
   principal_id = each.value.result.internal_id
@@ -49,15 +49,15 @@ resource "databricks_permission_assignment" "external_group" {
 }
 
 # Retrieve information about the corresponding workspace-level groups.
-data "databricks_group" "external_group" {
-  for_each = databricks_permission_assignment.external_group
+data "databricks_group" "this" {
+  for_each = databricks_permission_assignment.group
 
   display_name = each.value.display_name
 }
 
 # Set entitlements to the workspace-level groups.
-resource "databricks_entitlements" "external_group" {
-  for_each = data.databricks_group.external_group
+resource "databricks_entitlements" "group" {
+  for_each = data.databricks_group.this
 
   group_id              = each.value.id
   workspace_access      = var.groups[each.key].workspace_access
@@ -78,7 +78,7 @@ data "external" "resolve_service_principal_by_external_id" {
 
 # Assign the account-level service principals to the Databricks workspace.
 # This will create corresponding workspace-level service principals.
-resource "databricks_permission_assignment" "external_service_principal" {
+resource "databricks_permission_assignment" "service_principal" {
   for_each = data.external.resolve_service_principal_by_external_id
 
   principal_id = each.value.result.internal_id
@@ -91,15 +91,15 @@ resource "databricks_permission_assignment" "external_service_principal" {
 }
 
 # Retrieve information about the corresponding workspace-level service principals.
-data "databricks_service_principal" "external_service_principal" {
-  for_each = databricks_permission_assignment.external_service_principal
+data "databricks_service_principal" "this" {
+  for_each = databricks_permission_assignment.service_principal
 
   display_name = each.value.display_name
 }
 
 # Set entitlements to the workspace-level service principals.
-resource "databricks_entitlements" "external_service_principal" {
-  for_each = data.databricks_service_principal.external_service_principal
+resource "databricks_entitlements" "service_principal" {
+  for_each = data.databricks_service_principal.this
 
   service_principal_id  = each.value.id
   workspace_access      = var.service_principals[each.key].workspace_access

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -24,7 +24,7 @@ data "external" "current_metastore_assignment" {
 }
 
 data "external" "resolve_group_by_external_id" {
-  for_each = var.external_groups
+  for_each = var.groups
 
   program = [
     "bash", "${path.module}/resolve_group_by_external_id.sh",
@@ -40,7 +40,7 @@ resource "databricks_permission_assignment" "external_group" {
   for_each = data.external.resolve_group_by_external_id
 
   principal_id = each.value.result.internal_id
-  permissions  = var.external_groups[each.key].admin_access ? ["ADMIN"] : ["USER"]
+  permissions  = var.groups[each.key].admin_access ? ["ADMIN"] : ["USER"]
 
   depends_on = [
     # A metastore must be assigned to the Databricks workspace before permissions can be assigned to groups.
@@ -60,13 +60,13 @@ resource "databricks_entitlements" "external_group" {
   for_each = data.databricks_group.external_group
 
   group_id              = each.value.id
-  workspace_access      = var.external_groups[each.key].workspace_access
-  databricks_sql_access = var.external_groups[each.key].databricks_sql_access
-  allow_cluster_create  = var.external_groups[each.key].allow_cluster_create
+  workspace_access      = var.groups[each.key].workspace_access
+  databricks_sql_access = var.groups[each.key].databricks_sql_access
+  allow_cluster_create  = var.groups[each.key].allow_cluster_create
 }
 
 data "external" "resolve_service_principal_by_external_id" {
-  for_each = var.external_service_principals
+  for_each = var.service_principals
 
   program = [
     "bash", "${path.module}/resolve_service_principal_by_external_id.sh",
@@ -82,7 +82,7 @@ resource "databricks_permission_assignment" "external_service_principal" {
   for_each = data.external.resolve_service_principal_by_external_id
 
   principal_id = each.value.result.internal_id
-  permissions  = var.external_service_principals[each.key].admin_access ? ["ADMIN"] : ["USER"]
+  permissions  = var.service_principals[each.key].admin_access ? ["ADMIN"] : ["USER"]
 
   depends_on = [
     # A metastore must be assigned to the Databricks workspace before permissions can be assigned to service principals.
@@ -102,7 +102,7 @@ resource "databricks_entitlements" "external_service_principal" {
   for_each = data.databricks_service_principal.external_service_principal
 
   service_principal_id  = each.value.id
-  workspace_access      = var.external_service_principals[each.key].workspace_access
-  databricks_sql_access = var.external_service_principals[each.key].databricks_sql_access
-  allow_cluster_create  = var.external_service_principals[each.key].allow_cluster_create
+  workspace_access      = var.service_principals[each.key].workspace_access
+  databricks_sql_access = var.service_principals[each.key].databricks_sql_access
+  allow_cluster_create  = var.service_principals[each.key].allow_cluster_create
 }

--- a/modules/iam/moved.tf
+++ b/modules/iam/moved.tf
@@ -2,3 +2,23 @@ moved {
   from = time_rotating.this
   to   = time_rotating.token_expiration
 }
+
+moved {
+  from = databricks_entitlements.external_group
+  to   = databricks_entitlements.group
+}
+
+moved {
+  from = databricks_permission_assignment.external_group
+  to   = databricks_permission_assignment.group
+}
+
+moved {
+  from = databricks_entitlements.external_service_principal
+  to   = databricks_entitlements.service_principal
+}
+
+moved {
+  from = databricks_permission_assignment.external_service_principal
+  to   = databricks_permission_assignment.service_principal
+}

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -4,8 +4,8 @@ variable "workspace_url" {
   nullable    = false
 }
 
-variable "external_groups" {
-  description = "A map of external groups to assign to the Databricks workspace. To assign a group from Microsoft Entra ID, the external ID should match the Microsoft Entra group object ID."
+variable "groups" {
+  description = "A map of groups to assign to the Databricks workspace. To assign a group from Microsoft Entra ID, the external ID should match the Microsoft Entra group object ID."
   type = map(object({
     external_id           = string
     admin_access          = optional(bool, false)
@@ -17,8 +17,8 @@ variable "external_groups" {
   default  = {}
 }
 
-variable "external_service_principals" {
-  description = "A map of external service principals to assign to the Databricks workspace. To assign a service principal from Microsoft Entra ID, the external ID should match the Microsoft Entra service principal object ID."
+variable "service_principals" {
+  description = "A map of service principals to assign to the Databricks workspace. To assign a service principal from Microsoft Entra ID, the external ID should match the Microsoft Entra service principal object ID."
   type = map(object({
     external_id           = string
     admin_access          = optional(bool, false)


### PR DESCRIPTION
Remove `external_` prefix: local groups are considered a legacy feature, and the purpose of this module is to promote and simplify the use of external groups, so there should not be a reason to distinguish local and external groups.

Usually a breaking change, but this submodule currently has a note in its README stating that it's in an experimental stage and that breaking changes can be added without being marked as such.