### PR TITLE
refactor(iam): rename data sources

### DIFF
--- a/modules/iam/current_metastore_assignment.sh
+++ b/modules/iam/current_metastore_assignment.sh
@@ -21,16 +21,10 @@ readonly TOKEN
 
 # If the workspace was just created, it can take a while before a metastore has
 # been assigned to it.
-RETRY_MAX_TIME_IN_SECONDS=1800 # 30 minutes
-readonly RETRY_MAX_TIME_IN_SECONDS
+END_TIME_SECONDS=$((SECONDS + 1800)) # 30 minutes
+readonly END_TIME_SECONDS
 
-RETRY_DELAY_IN_SECONDS=10
-readonly RETRY_DELAY_IN_SECONDS
-
-NUMBER_OF_RETRIES=$(( RETRY_MAX_TIME_IN_SECONDS / RETRY_DELAY_IN_SECONDS ))
-readonly NUMBER_OF_RETRIES
-
-for (( i=0; i<"$NUMBER_OF_RETRIES"; i++ )); do
+while [[ "$SECONDS" -lt "$END_TIME_SECONDS" ]]; do
   response=$(curl --silent --show-error \
     --request GET "$API_URL" \
     --header "Authorization: Bearer $TOKEN" \
@@ -43,8 +37,8 @@ for (( i=0; i<"$NUMBER_OF_RETRIES"; i++ )); do
     exit 0
   fi
 
-  sleep "${RETRY_DELAY_IN_SECONDS}s"
+  sleep 10s
 done
 
-echo "Unhandled error after $NUMBER_OF_RETRIES retries (${RETRY_MAX_TIME_IN_SECONDS}s): $response" >&2
+echo "Unhandled error: $response" >&2
 exit 1

--- a/modules/iam/resolve_service_principal_proxy.sh
+++ b/modules/iam/resolve_service_principal_proxy.sh
@@ -7,7 +7,7 @@
 # Ref: https://docs.databricks.com/api/azure/workspace/iamv2/resolveserviceprincipalproxy
 #
 # Usage:
-#   ./resolve_service_principal_by_external_id.sh <WORKSPACE_URL> <TOKEN> <EXTERNAL_ID>
+#   ./resolve_service_principal_proxy.sh <WORKSPACE_URL> <TOKEN> <EXTERNAL_ID>
 
 set -e
 
@@ -23,18 +23,12 @@ readonly TOKEN
 EXTERNAL_ID="$3"
 readonly EXTERNAL_ID
 
-# If the Entra ID service principal was just created, it can take a few attempts
-# before it can be resolved in Databricks.
-RETRY_MAX_TIME_IN_SECONDS=1800 # 30 minutes
-readonly RETRY_MAX_TIME_IN_SECONDS
+# If the Entra ID service principal was just created, it can a while before it
+# can be resolved in Databricks.
+END_TIME_SECONDS=$((SECONDS + 1800)) # 30 minutes
+readonly END_TIME_SECONDS
 
-RETRY_DELAY_IN_SECONDS=10
-readonly RETRY_DELAY_IN_SECONDS
-
-NUMBER_OF_RETRIES=$(( RETRY_MAX_TIME_IN_SECONDS / RETRY_DELAY_IN_SECONDS ))
-readonly NUMBER_OF_RETRIES
-
-for (( i=0; i<"$NUMBER_OF_RETRIES"; i++ )); do
+while [[ "$SECONDS" -lt "$END_TIME_SECONDS" ]]; do
   response=$(curl --silent --show-error \
     --request POST "$API_URL" \
     --header "Authorization: Bearer $TOKEN" \
@@ -53,8 +47,8 @@ for (( i=0; i<"$NUMBER_OF_RETRIES"; i++ )); do
     exit 0
   fi
 
-  sleep "${RETRY_DELAY_IN_SECONDS}s"
+  sleep 10s
 done
 
-echo "Unhandled error after $NUMBER_OF_RETRIES retries (${RETRY_MAX_TIME_IN_SECONDS}s): $response" >&2
+echo "Unhandled error: $response" >&2
 exit 1


### PR DESCRIPTION
## Rename data sources

- Rename `data.databricks_group.external_group` to `data.databricks_group.external`, removing duplicate word `group`.
- Rename `data.databricks_service_principal.external_service_principal` to `data.databricks_service_principal.external`, removing duplicate word `service_principal`.
- Rename `data.external.resolve_group_by_external_id` to `data.external.resolve_group_proxy`, clarifying that this data source calls an external proxy program for resolving a group ID.
- Rename `data.external.resolve_service_principal_by_external_id` to `data.external.resolve_service_principal_proxy`, clarifying that this data source calls and external proxy program for resolving a service principal ID.

## Rename external programs

- Rename `resolve_group_by_external_id.sh` to `resolve_group_proxy.sh`, same renaming as the data source that calls this program.
- Rename `resolve_service_principal_by_external_id.sh` to `resolve_service_principal_proxy.sh`, same renaming as the data source that calls this program.

## Update external programs

Replace `for` loops with `while` loops to clarify that we're not attempting to call the proxy API a certain number of times, but we're giving some time for changes to propagate to the account level.