### PR TITLE
refactor(iam-v2): remove `external_` prefix from variable and resource names

### DIFF
--- a/modules/iam-v2/README.md
+++ b/modules/iam-v2/README.md
@@ -29,7 +29,7 @@ module "databricks_iam_v2" {
   version = "~> 4.3"
 
   workspace_url = data.azurerm_databricks_workspace.example.workspace_url
-  external_groups = {
+  groups = {
     "users" = {
       external_id = "85e19454-004b-4d13-bb08-21978c58a927" # Object ID from Entra ID
     }
@@ -39,7 +39,7 @@ module "databricks_iam_v2" {
       admin_access = true
     }
   }
-  external_service_principals = {
+  service_principals = {
     "deploy" = {
       external_id          = "d642b4b1-5d5a-42d2-9323-ac1677bffada" # Object ID from Entra ID
       allow_cluster_create = true

--- a/modules/iam-v2/main.tf
+++ b/modules/iam-v2/main.tf
@@ -24,7 +24,7 @@ data "external" "current_metastore_assignment" {
 }
 
 data "external" "resolve_group_proxy" {
-  for_each = var.external_groups
+  for_each = var.groups
 
   program = [
     "bash", "${path.module}/resolve_group_proxy.sh",
@@ -40,7 +40,7 @@ resource "databricks_permission_assignment" "group" {
   for_each = data.external.resolve_group_proxy
 
   principal_id = each.value.result.internal_id
-  permissions  = var.external_groups[each.key].admin_access ? ["ADMIN"] : ["USER"]
+  permissions  = var.groups[each.key].admin_access ? ["ADMIN"] : ["USER"]
 
   depends_on = [
     # A metastore must be assigned to the Databricks workspace before permissions can be assigned to groups.
@@ -60,13 +60,13 @@ resource "databricks_entitlements" "group" {
   for_each = data.databricks_group.this
 
   group_id              = each.value.id
-  workspace_access      = var.external_groups[each.key].workspace_access
-  databricks_sql_access = var.external_groups[each.key].databricks_sql_access
-  allow_cluster_create  = var.external_groups[each.key].allow_cluster_create
+  workspace_access      = var.groups[each.key].workspace_access
+  databricks_sql_access = var.groups[each.key].databricks_sql_access
+  allow_cluster_create  = var.groups[each.key].allow_cluster_create
 }
 
 data "external" "resolve_service_principal_proxy" {
-  for_each = var.external_service_principals
+  for_each = var.service_principals
 
   program = [
     "bash", "${path.module}/resolve_service_principal_proxy.sh",
@@ -82,7 +82,7 @@ resource "databricks_permission_assignment" "service_principal" {
   for_each = data.external.resolve_service_principal_proxy
 
   principal_id = each.value.result.internal_id
-  permissions  = var.external_service_principals[each.key].admin_access ? ["ADMIN"] : ["USER"]
+  permissions  = var.service_principals[each.key].admin_access ? ["ADMIN"] : ["USER"]
 
   depends_on = [
     # A metastore must be assigned to the Databricks workspace before permissions can be assigned to service principals.
@@ -102,7 +102,7 @@ resource "databricks_entitlements" "service_principal" {
   for_each = data.databricks_service_principal.this
 
   service_principal_id  = each.value.id
-  workspace_access      = var.external_service_principals[each.key].workspace_access
-  databricks_sql_access = var.external_service_principals[each.key].databricks_sql_access
-  allow_cluster_create  = var.external_service_principals[each.key].allow_cluster_create
+  workspace_access      = var.service_principals[each.key].workspace_access
+  databricks_sql_access = var.service_principals[each.key].databricks_sql_access
+  allow_cluster_create  = var.service_principals[each.key].allow_cluster_create
 }

--- a/modules/iam-v2/main.tf
+++ b/modules/iam-v2/main.tf
@@ -36,7 +36,7 @@ data "external" "resolve_group_proxy" {
 
 # Assign the account-level groups to the Databricks workspace.
 # This will create corresponding workspace-level groups.
-resource "databricks_permission_assignment" "external_group" {
+resource "databricks_permission_assignment" "group" {
   for_each = data.external.resolve_group_proxy
 
   principal_id = each.value.result.internal_id
@@ -49,15 +49,15 @@ resource "databricks_permission_assignment" "external_group" {
 }
 
 # Retrieve information about the corresponding workspace-level groups.
-data "databricks_group" "external" {
-  for_each = databricks_permission_assignment.external_group
+data "databricks_group" "this" {
+  for_each = databricks_permission_assignment.group
 
   display_name = each.value.display_name
 }
 
 # Set entitlements to the workspace-level groups.
-resource "databricks_entitlements" "external_group" {
-  for_each = data.databricks_group.external
+resource "databricks_entitlements" "group" {
+  for_each = data.databricks_group.this
 
   group_id              = each.value.id
   workspace_access      = var.external_groups[each.key].workspace_access
@@ -78,7 +78,7 @@ data "external" "resolve_service_principal_proxy" {
 
 # Assign the account-level service principals to the Databricks workspace.
 # This will create corresponding workspace-level service principals.
-resource "databricks_permission_assignment" "external_service_principal" {
+resource "databricks_permission_assignment" "service_principal" {
   for_each = data.external.resolve_service_principal_proxy
 
   principal_id = each.value.result.internal_id
@@ -91,15 +91,15 @@ resource "databricks_permission_assignment" "external_service_principal" {
 }
 
 # Retrieve information about the corresponding workspace-level service principals.
-data "databricks_service_principal" "external" {
-  for_each = databricks_permission_assignment.external_service_principal
+data "databricks_service_principal" "this" {
+  for_each = databricks_permission_assignment.service_principal
 
   display_name = each.value.display_name
 }
 
 # Set entitlements to the workspace-level service principals.
-resource "databricks_entitlements" "external_service_principal" {
-  for_each = data.databricks_service_principal.external
+resource "databricks_entitlements" "service_principal" {
+  for_each = data.databricks_service_principal.this
 
   service_principal_id  = each.value.id
   workspace_access      = var.external_service_principals[each.key].workspace_access

--- a/modules/iam-v2/moved.tf
+++ b/modules/iam-v2/moved.tf
@@ -2,3 +2,23 @@ moved {
   from = time_rotating.this
   to   = time_rotating.token_expiration
 }
+
+moved {
+  from = databricks_permission_assignment.external_group
+  to   = databricks_permission_assignment.group
+}
+
+moved {
+  from = databricks_entitlements.external_group
+  to   = databricks_entitlements.group
+}
+
+moved {
+  from = databricks_permission_assignment.external_service_principal
+  to   = databricks_permission_assignment.service_principal
+}
+
+moved {
+  from = databricks_entitlements.external_service_principal
+  to   = databricks_entitlements.service_principal
+}

--- a/modules/iam-v2/variables.tf
+++ b/modules/iam-v2/variables.tf
@@ -4,7 +4,7 @@ variable "workspace_url" {
   nullable    = false
 }
 
-variable "external_groups" {
+variable "groups" {
   description = "A map of external groups to assign to the Databricks workspace. To assign a group from Microsoft Entra ID, the external ID should match the Microsoft Entra group object ID."
   type = map(object({
     external_id           = string
@@ -17,7 +17,7 @@ variable "external_groups" {
   default  = {}
 }
 
-variable "external_service_principals" {
+variable "service_principals" {
   description = "A map of external service principals to assign to the Databricks workspace. To assign a service principal from Microsoft Entra ID, the external ID should match the Microsoft Entra service principal object ID."
   type = map(object({
     external_id           = string


### PR DESCRIPTION
The `iam-v2` submodule will only be used to manage **external identities**, and a new `iam` submodule will be implemented to manage **Databricks identities**, so no need to specify when the entire purpose of the `iam-v2` submodule is to manage external identities.

No need to mark as breaking change, since this submodule is still marked as in beta.

Release-As: 4.3.1
