### PR TITLE
feat(iam-v2): handle known error code `NOT_IMPLEMENTED`

### DIFF
--- a/modules/iam-v2/resolve_group_proxy.sh
+++ b/modules/iam-v2/resolve_group_proxy.sh
@@ -46,6 +46,14 @@ while [[ "$SECONDS" -lt "$END_TIME_SECONDS" ]]; do
     exit 0
   fi
 
+  error_code=$(echo "$response" | jq -r .error_code)
+  case "$error_code" in
+    "NOT_IMPLEMENTED")
+      echo "Error ($error_code): Automatic identity management is not enabled for this workspace." >&2
+      exit 1
+    ;;
+  esac
+
   sleep 10s
 done
 

--- a/modules/iam-v2/resolve_service_principal_proxy.sh
+++ b/modules/iam-v2/resolve_service_principal_proxy.sh
@@ -47,6 +47,14 @@ while [[ "$SECONDS" -lt "$END_TIME_SECONDS" ]]; do
     exit 0
   fi
 
+  error_code=$(echo "$response" | jq -r .error_code)
+  case "$error_code" in
+    "NOT_IMPLEMENTED")
+      echo "Error ($error_code): Automatic identity management is not enabled for this workspace." >&2
+      exit 1
+    ;;
+  esac
+
   sleep 10s
 done
 


### PR DESCRIPTION
Error code `NOT_IMPLEMENTED` is returned if Automatic Identity Management is not enabled for the Databricks workspace. If this error code is returned, return with exit code 1 instead of continuing the loop for 30 minutes.